### PR TITLE
bug: workaround for broken rerender on return

### DIFF
--- a/src/app/shared/components/template/services/template-nav.service.ts
+++ b/src/app/shared/components/template/services/template-nav.service.ts
@@ -62,7 +62,7 @@ export class TemplateNavService {
       // TODO - this could also be handled by having a default nav_resume action that emits force_rerender
       // force rerender on top-most template only
       if (!parent) {
-        await container.forceRerender(false);
+        await container.forceRerender(true);
       }
       // trigger any actions defined for the nav_resume trigger on all templates
       await container.templateActionService.handleActions([


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

Provides a workaround for the bug in issue #13. Forces the rerender on return to be full rather than trying to just rerender child components. This results in a slightly worse user experience, as when navigating back the page briefly flickers to completely reload.

## Git Issues

Closes #13 

## Screenshots/Videos


https://user-images.githubusercontent.com/64838927/190562549-e4570ca9-7c02-4912-9164-85f990beccf1.mov


