### PR TITLE
feat: hide empty components

### DIFF
--- a/src/app/shared/components/template/template-component.scss
+++ b/src/app/shared/components/template/template-component.scss
@@ -21,13 +21,22 @@ plh-template-container {
 }
 
 /// Ensure all directly nested template rows have spacing between elements,
-/// except in case where only one row (e.g. deep-nested)
 plh-template-container > plh-template-component:not([data-hidden="true"]) {
   margin-top: 1em;
+  // except in case where component has an empty value and is of type text, image, title or subtitle
+  &[data-empty="true"] {
+    margin-top: 0;
+  }
 }
+// except in case where only one row (e.g. deep-nested)
 plh-template-container > plh-template-component:not([data-hidden="true"]):first-of-type {
   margin-top: 0;
 }
+
+// plh-template-container > plh-template-component[data-empty="true"] {
+//   margin-top: 0;
+// }
+
 /// Ensure standalone containers and components fill all available space
 plh-template-container:not([data-hidden="true"]):only-child,
 plh-template-component:not([data-hidden="true"]):only-child {

--- a/src/app/shared/components/template/template-component.ts
+++ b/src/app/shared/components/template/template-component.ts
@@ -86,6 +86,13 @@ export class TemplateComponent implements OnInit, AfterContentInit, ITemplateRow
   @HostBinding("attr.data-hidden") get getAttrHidden() {
     return this._row && this._row.hidden ? true : false; // explictly state for all components to allow css selection
   }
+  @HostBinding("attr.data-empty") get getAttrEmpty() {
+    return this._row &&
+      ["text", "title", "image", "subtitle"].includes(this._row.type) &&
+      !this._row.value
+      ? true
+      : false; // explictly state for all components to allow css selection
+  }
   @HostBinding("attr.data-name") get getComponentName() {
     return this._row?.name || null;
   }


### PR DESCRIPTION
PR Checklist

- [x] - Latest `master` branch merged
- [x] - PR title descriptive (can be used in release notes)

## Description

When a text, title, subtitle or image component has no "value", it will no longer take up space on the page. Previously the component container would still have a top margin in these cases.